### PR TITLE
Fix CI pipeline by escaping '-' sign

### DIFF
--- a/jenkins-pipeline
+++ b/jenkins-pipeline
@@ -1,2 +1,2 @@
 library 'continuous_integration_pipeline'
-ciPipeline("--cmake-args \-DCMAKE_BUILD_TYPE=Release --ignore eigen3")
+ciPipeline("--cmake-args=\"-DCMAKE_BUILD_TYPE=Release\" --ignore eigen3")

--- a/jenkins-pipeline
+++ b/jenkins-pipeline
@@ -1,2 +1,2 @@
 library 'continuous_integration_pipeline'
-ciPipeline("--cmake-args '-DCMAKE_BUILD_TYPE=Release' --ignore eigen3")
+ciPipeline("--cmake-args \-DCMAKE_BUILD_TYPE=Release --ignore eigen3")


### PR DESCRIPTION
This PR should fix the issue.
It seems like Jenkins or Bash pre-processed the single quotes, and what was left was `--cmake-args -DCMAKE_BUILD_TYPE`, which Python's _argparse_ interprets as two options.

1. `--cmake-args` (no arguments)
2. `-D CMAKE_BUILD_TYPE`

i.e. a mess. 

Now what's strange is that this behaviour seems to have changed suddenly. 